### PR TITLE
feat: add contextmenu handler

### DIFF
--- a/back/schema.gql
+++ b/back/schema.gql
@@ -84,8 +84,8 @@ input follow {
   follower: user
   checked: Boolean = false
   blocked: Boolean = false
-  createdAt: DateTime = "2021-07-21T12:19:37.274Z"
-  modifiedAt: DateTime = "2021-07-21T12:19:37.274Z"
+  createdAt: DateTime = "2021-07-23T07:56:36.279Z"
+  modifiedAt: DateTime = "2021-07-23T07:56:36.279Z"
 }
 
 input user {
@@ -99,8 +99,8 @@ input user {
   followings: [follow!]
   followers: [follow!]
   userState: String = "login"
-  createdAt: DateTime = "2021-07-21T12:19:37.276Z"
-  modifiedAt: DateTime = "2021-07-21T12:19:37.276Z"
+  createdAt: DateTime = "2021-07-23T07:56:36.280Z"
+  modifiedAt: DateTime = "2021-07-23T07:56:36.280Z"
 }
 
 type Query {

--- a/front/src/UI/molecules/Alarm/AlarmUser/index.tsx
+++ b/front/src/UI/molecules/Alarm/AlarmUser/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 
-import { Avatar, AvatarBadge, Flex, Box, Text } from '@chakra-ui/react';
+import { Avatar, AvatarBadge, Flex, Box, Text, useToast } from '@chakra-ui/react';
 import { ContextMenu } from 'holee-contextmenu';
 
 import {
@@ -9,11 +9,18 @@ import {
   ALARM_MESSAGE_LOGOUT_USER_STATE_COLOR,
   ALARM_CONTENT_FONTWEIGHT,
   ALARM_USER_NICKNAME_FONTSIZE,
+  TOAST_DURATION,
+  TOAST_SEND_MESSAGE_TITLE,
+  TOAST_SEND_MESSAGE_DESCRIPTION,
+  TOAST_ADD_FRIEND_TITLE,
+  TOAST_ADD_FRIEND_DESCRIPTION,
 } from '../../../../utils/constants';
 
 export const AlarmUser = ({ nickName, userState, avatar }: { nickName: string; userState: string; avatar: string }) => {
   const outerRef = useRef<HTMLDivElement>(null);
+  const toast = useToast();
   let avatarState = '';
+
   if (userState === 'login') {
     avatarState = ALARM_MESSAGE_LOGIN_USER_STATE_COLOR;
   } else if (userState === 'playing') {
@@ -25,36 +32,54 @@ export const AlarmUser = ({ nickName, userState, avatar }: { nickName: string; u
   const menuOnClickHandler = (e: React.MouseEvent | React.KeyboardEvent<HTMLUListElement>) => {
     const eventTarget = e.target as HTMLUListElement;
     if (eventTarget) {
-      console.log(eventTarget.dataset.option);
+      switch (eventTarget.dataset.option) {
+        case 'profile':
+          break;
+        case 'send-message':
+          toast({
+            title: TOAST_SEND_MESSAGE_TITLE,
+            description: TOAST_SEND_MESSAGE_DESCRIPTION,
+            status: 'success',
+            duration: TOAST_DURATION,
+            isClosable: true,
+          });
+          break;
+        case 'add-friend':
+          toast({
+            title: TOAST_ADD_FRIEND_TITLE,
+            description: TOAST_ADD_FRIEND_DESCRIPTION,
+            status: 'success',
+            duration: TOAST_DURATION,
+            isClosable: true,
+          });
+          break;
+        case 'play-game':
+          break;
+        default:
+      }
     }
   };
 
   return (
     <>
       <ContextMenu outerRef={outerRef} menuOnClick={(e) => menuOnClickHandler(e)}>
-        <li data-option="profile">profile</li>
-        <li data-option="send-message">send message</li>
-        <li data-option="add-friend">add friend</li>
-        <li data-option="play-game">play game</li>
-        <li data-option="register-admin">register admin(dismissal)</li>
-        <li data-option="block">block(unblock)</li>
-        <li data-option="mute">mute(unmute)</li>
-        <li data-option="forced-out">forced out</li>
+        <li data-option="profile">{nickName}의 프로필 보기</li>
+        <li data-option="send-message">메세지 보내기</li>
+        <li data-option="add-friend">친구추가 요청</li>
+        <li data-option="play-game">핑퐁게임 요청</li>
       </ContextMenu>
-      <div style={{ backgroundColor: 'red', width: '380' }} ref={outerRef}>
-        <Flex p="2" justifyContent="flex-start">
-          <Box>
-            <Avatar size="xs" src={avatar}>
-              <AvatarBadge boxSize="1.25em" bg={avatarState} />
-            </Avatar>
-          </Box>
-          <Box pl="4">
-            <Text fontSize={ALARM_USER_NICKNAME_FONTSIZE} fontWeight={ALARM_CONTENT_FONTWEIGHT}>
-              {nickName}
-            </Text>
-          </Box>
-        </Flex>
-      </div>
+      <Flex p="2" justifyContent="flex-start" ref={outerRef}>
+        <Box>
+          <Avatar size="xs" src={avatar}>
+            <AvatarBadge boxSize="1.25em" bg={avatarState} />
+          </Avatar>
+        </Box>
+        <Box pl="4">
+          <Text fontSize={ALARM_USER_NICKNAME_FONTSIZE} fontWeight={ALARM_CONTENT_FONTWEIGHT}>
+            {nickName}
+          </Text>
+        </Box>
+      </Flex>
     </>
   );
 };

--- a/front/src/UI/molecules/Alarm/AlarmUser/index.tsx
+++ b/front/src/UI/molecules/Alarm/AlarmUser/index.tsx
@@ -14,6 +14,8 @@ import {
   TOAST_SEND_MESSAGE_DESCRIPTION,
   TOAST_ADD_FRIEND_TITLE,
   TOAST_ADD_FRIEND_DESCRIPTION,
+  TOAST_PLAY_GAME_TITLE,
+  TOAST_PLAY_GAME_DESCRIPTION,
 } from '../../../../utils/constants';
 
 export const AlarmUser = ({ nickName, userState, avatar }: { nickName: string; userState: string; avatar: string }) => {
@@ -54,6 +56,13 @@ export const AlarmUser = ({ nickName, userState, avatar }: { nickName: string; u
           });
           break;
         case 'play-game':
+          toast({
+            title: TOAST_PLAY_GAME_TITLE,
+            description: TOAST_PLAY_GAME_DESCRIPTION,
+            status: 'success',
+            duration: TOAST_DURATION,
+            isClosable: true,
+          });
           break;
         default:
       }

--- a/front/src/utils/constants.ts
+++ b/front/src/utils/constants.ts
@@ -1,4 +1,16 @@
 /*
+ ** toast
+ */
+
+export const TOAST_DURATION = 3000;
+export const TOAST_SEND_MESSAGE_TITLE = '메세지 알림';
+export const TOAST_SEND_MESSAGE_DESCRIPTION = '메세지를 성공적으로 보냈습니다.';
+export const TOAST_ADD_FRIEND_TITLE = '친구 추가 알림';
+export const TOAST_ADD_FRIEND_DESCRIPTION = '친구 추가 완료되었습니다.';
+export const TOAST_PLAY_GAME_TITLE = '게임 알림';
+export const TOAST_PLAY_GAME_DESCRIPTION = '게임 신청을 완료했습니다.';
+
+/*
  ** URL
  */
 


### PR DESCRIPTION
> Issue number (if there is an associated issue)

#102 

- 우클릭시 contextmenu
<img src="https://user-images.githubusercontent.com/22424891/126759622-684d9d58-d0a0-45c2-a2ea-e05fea17282d.png" height="200px"/>

- contextmenu list 눌렀을 때 toast trigger
<img src="https://user-images.githubusercontent.com/22424891/126759365-094f45e5-a19a-4530-b8ed-67119da24587.png" height="200px"/>


- 해당 contextmenu의 로직은 아래에 기입됩니다.
```js
 const menuOnClickHandler = (e: React.MouseEvent | React.KeyboardEvent<HTMLUListElement>) => {
    const eventTarget = e.target as HTMLUListElement;
    if (eventTarget) {
      switch (eventTarget.dataset.option) {
        case 'profile':
          ...
          break;
        case 'send-message':
          ...
          break;
        case 'add-friend':
          ...
          break;
        case 'play-game':
          ...
          break;
        default:
      }
    }
  };
```

## Next

query 문 짜기